### PR TITLE
[Feat/#1] 사용자인증구현(sms회원가입,로그인,로그아웃)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,9 @@ dependencies {
     // Spring Boot 테스트 기능
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // 문자인증을 위한 라이브러리
+    implementation 'net.nurigo:sdk:4.3.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/season/livingmate/LivingmateApplication.java
+++ b/src/main/java/com/season/livingmate/LivingmateApplication.java
@@ -2,7 +2,9 @@ package com.season.livingmate;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class LivingmateApplication {
 

--- a/src/main/java/com/season/livingmate/auth/controller/DummyController.java
+++ b/src/main/java/com/season/livingmate/auth/controller/DummyController.java
@@ -1,0 +1,48 @@
+package com.season.livingmate.auth.controller;
+
+import com.season.livingmate.auth.dto.request.LoginReqDto;
+import com.season.livingmate.exception.Response;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "로그인/로그아웃", description = "로그인/로그아웃 API")
+@RequestMapping("/auth")
+public class DummyController {
+
+
+    @PostMapping("/login")
+    @Operation(summary = "로그인", description = "사용자 로그인 후 accessToken과 refreshToken을 반환합니다.(필터에서 실제 처리됨)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "로그인 성공",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = Response.class))),
+    })
+    public void swaggerLoginDummy(@RequestBody LoginReqDto request) {
+        // 실제 동작은 필터에서 처리하므로 바디는 비워둬도 됨
+    }
+
+    @Operation(summary = "로그아웃",
+            description = "사용자를 로그아웃 처리합니다. (필터에서 실제 처리됨)",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "로그아웃 성공",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = Response.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = Response.class)))
+    })
+    @PostMapping("/logout")
+    public void swaggerLogoutDummy() {
+        // 실제 로그아웃 로직은 LogoutFilter에서 처리됨
+    }
+}

--- a/src/main/java/com/season/livingmate/auth/controller/DummyController.java
+++ b/src/main/java/com/season/livingmate/auth/controller/DummyController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@Tag(name = "로그인/로그아웃", description = "로그인/로그아웃 API")
+@Tag(name = "로그인/로그아웃", description = "로그인/로그아웃 API - Swagger 문서화를 위한 껍데기 컨트롤러이므로 실제작동X")
 @RequestMapping("/auth")
 public class DummyController {
 

--- a/src/main/java/com/season/livingmate/auth/controller/RefreshTokenController.java
+++ b/src/main/java/com/season/livingmate/auth/controller/RefreshTokenController.java
@@ -1,0 +1,66 @@
+package com.season.livingmate.auth.controller;
+
+import com.season.livingmate.auth.dto.response.RefreshTokenResDto;
+import com.season.livingmate.auth.service.RefreshTokenService;
+import com.season.livingmate.exception.CustomException;
+import com.season.livingmate.exception.Response;
+import com.season.livingmate.exception.status.ErrorStatus;
+import com.season.livingmate.exception.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "토큰재발급", description = "토큰재발급 API")
+@RequestMapping("/auth")
+@Slf4j
+public class RefreshTokenController {
+
+    private final RefreshTokenService refreshTokenService;
+
+    @Operation(summary = "토큰 갱신", description = "헤더의 refresh token으로 access token을 재발급합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "토큰 갱신 성공",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = Response.class)))
+    })
+    @GetMapping("/refresh")
+    public ResponseEntity<Response<RefreshTokenResDto>> refreshToken(
+            @RequestHeader(name = "Authorization", required = false) String authHeader) {
+
+        if (!isBearerToken(authHeader)) {
+            return ResponseEntity.badRequest()
+                    .body(Response.fail(ErrorStatus.RESOURCE_NOT_FOUND));
+        }
+
+        String refreshToken = authHeader.substring(7); // "Bearer " 제거
+
+        try {
+            RefreshTokenResDto tokenResDto = refreshTokenService.refreshToken(refreshToken);
+            return ResponseEntity.ok(Response.success(SuccessStatus.SUCCESS, tokenResDto));
+        } catch (CustomException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(Response.fail(e.getErrorCode()));
+        } catch (Exception e) {
+            log.error("Refresh token error", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Response.fail(ErrorStatus.INTERNAL_SERVER_ERROR));
+        }
+    }
+
+    private boolean isBearerToken(String authHeader) {
+        return authHeader != null && authHeader.startsWith("Bearer ");
+    }
+
+}

--- a/src/main/java/com/season/livingmate/auth/controller/SignupController.java
+++ b/src/main/java/com/season/livingmate/auth/controller/SignupController.java
@@ -1,0 +1,83 @@
+package com.season.livingmate.auth.controller;
+
+import com.season.livingmate.auth.dto.request.SendOtpReqDto;
+import com.season.livingmate.auth.dto.request.SignupReqDto;
+import com.season.livingmate.auth.dto.request.VerifyOtpReqDto;
+import com.season.livingmate.auth.dto.response.SignupResDto;
+import com.season.livingmate.auth.service.SignupService;
+import com.season.livingmate.exception.CustomException;
+import com.season.livingmate.exception.Response;
+import com.season.livingmate.exception.status.ErrorStatus;
+import com.season.livingmate.exception.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Singup", description = "sms문자인증을 통한 회원가입")
+@RequestMapping("/auth")
+public class SignupController {
+    private final SignupService signupService;
+
+    @Operation(summary = "회원가입", description = "기본 정보를 등록합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원가입 성공",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = Response.class)))
+    })
+    @PostMapping("/signup")
+    public ResponseEntity<Response<SignupReqDto>> signup(@RequestBody @Valid SignupReqDto signupReqDto){
+        try {
+            signupService.signup(signupReqDto);
+            return ResponseEntity.ok(Response.success(SuccessStatus.SUCCESS, null));
+        }catch (CustomException e){
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(Response.fail(e.getErrorCode()));
+        }
+    }
+
+    @PostMapping("/send-one")
+    @Operation(summary = "OTP 전송", description = "사용자의 전화번호로 일회용 OTP를 전송합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OTP 전송 성공",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = Response.class))),
+    })
+    public ResponseEntity<Response<String>> sendOtp(@RequestBody @Valid SendOtpReqDto sendOtpReqDto) throws Exception {
+        try{
+            signupService.sendOtp(sendOtpReqDto.getPhoneNumber());
+            return ResponseEntity.ok(Response.success(SuccessStatus.SUCCESS, null));
+        } catch (CustomException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body((Response.fail(e.getErrorCode())));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body((Response.fail(ErrorStatus.INTERNAL_SERVER_ERROR)));
+        }
+    }
+
+    @PostMapping("/verify-otp")
+    @Operation(summary = "OTP 검증", description = "사용자가 입력한 OTP를 검증하고 회원가입을 완료합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OTP 검증 성공 및 회원가입 완료"
+            )
+    })
+    public ResponseEntity<Response<SignupResDto>> verifyOtp(@RequestBody @Valid VerifyOtpReqDto request) throws Exception {
+        try{
+            SignupResDto signupResDto = signupService.verifyOtp(request);
+            return ResponseEntity.ok(Response.success(SuccessStatus.SUCCESS, signupResDto));
+        }catch (CustomException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.fail(e.getErrorCode()));
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Response.fail(ErrorStatus.INTERNAL_SERVER_ERROR));
+        }
+    }
+}

--- a/src/main/java/com/season/livingmate/auth/dto/request/LoginReqDto.java
+++ b/src/main/java/com/season/livingmate/auth/dto/request/LoginReqDto.java
@@ -1,0 +1,17 @@
+package com.season.livingmate.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class LoginReqDto {
+
+    @NotBlank(message = "아이디는 필수입니다.")
+    @Schema(description = "사용자 아이디", example = "testuser", required = true)
+    private String username;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Schema(description = "사용자 비밀번호", example = "password123", required = true)
+    private String password;
+}

--- a/src/main/java/com/season/livingmate/auth/dto/request/SendOtpReqDto.java
+++ b/src/main/java/com/season/livingmate/auth/dto/request/SendOtpReqDto.java
@@ -1,4 +1,15 @@
 package com.season.livingmate.auth.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
 public class SendOtpReqDto {
+
+    @NotBlank(message = "폰번호는 필수입니다.")
+    @Schema(description = "사용자 휴대폰 번호", example = "01012345678", required = true)
+    private String phoneNumber;
 }

--- a/src/main/java/com/season/livingmate/auth/dto/request/SendOtpReqDto.java
+++ b/src/main/java/com/season/livingmate/auth/dto/request/SendOtpReqDto.java
@@ -1,0 +1,4 @@
+package com.season.livingmate.auth.dto.request;
+
+public class SendOtpReqDto {
+}

--- a/src/main/java/com/season/livingmate/auth/dto/request/SignupReqDto.java
+++ b/src/main/java/com/season/livingmate/auth/dto/request/SignupReqDto.java
@@ -11,7 +11,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class SignupResDto {
+public class SignupReqDto {
     @NotBlank(message = "아이디는 필수입니다.")
     @Schema(description = "사용자 아이디", example = "testuser", required = true)
     private String username;

--- a/src/main/java/com/season/livingmate/auth/dto/request/SignupResDto.java
+++ b/src/main/java/com/season/livingmate/auth/dto/request/SignupResDto.java
@@ -1,0 +1,56 @@
+package com.season.livingmate.auth.dto.request;
+
+import com.season.livingmate.user.entity.Gender;
+import com.season.livingmate.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SignupResDto {
+    @NotBlank(message = "아이디는 필수입니다.")
+    @Schema(description = "사용자 아이디", example = "testuser", required = true)
+    private String username;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Schema(description = "사용자 비밀번호", example = "password123", required = true)
+    private String password;
+
+    @NotNull
+    @Schema(description = "사용자 성별", example = "MALE", required = true)
+    private Gender gender;
+
+    @NotBlank(message = "비밀번호 확인은 필수입니다.")
+    @Schema(description = "비밀번호 확인", example = "password123", required = true)
+    private String confirmPassword;
+
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Schema(description = "사용자 닉네임", example = "nickname123", required = true)
+    private String nickname;
+
+    @Schema(description = "사용자 나이", example = "25")
+    private int age;
+
+    @Schema(description = "사용자가 방을 가지고 있는지 여부", example = "true")
+    private boolean isRoom;
+
+    @AssertTrue(message = "비밀번호와 비밀번호 확인이 일치하지 않습니다.")
+    public boolean isPasswordMatching() {
+        return password != null && password.equals(confirmPassword);
+    }
+
+    public User toEntity(String encodedPassword){
+        return User.builder()
+                .nickname(nickname)
+                .username(username)
+                .password(encodedPassword)
+                .gender(gender)
+                .age(age)
+                .isRoom(isRoom)
+                .build();
+    }
+}

--- a/src/main/java/com/season/livingmate/auth/dto/request/VerifyOtpReqDto.java
+++ b/src/main/java/com/season/livingmate/auth/dto/request/VerifyOtpReqDto.java
@@ -1,0 +1,4 @@
+package com.season.livingmate.auth.dto.request;
+
+public class VerifyOtpReqDto {
+}

--- a/src/main/java/com/season/livingmate/auth/dto/request/VerifyOtpReqDto.java
+++ b/src/main/java/com/season/livingmate/auth/dto/request/VerifyOtpReqDto.java
@@ -1,4 +1,22 @@
 package com.season.livingmate.auth.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
 public class VerifyOtpReqDto {
+
+    @Schema(description = "사용자 아이디", example = "testuser", required = true)
+    private String username;
+
+    @NotBlank(message = "폰번호는 필수입니다.")
+    @Schema(description = "사용자 휴대폰 번호", example = "01012345678", required = true)
+    String phoneNumber;
+
+    @NotBlank(message = "인증번호는 필수입니다")
+    @Schema(description = "전송된 OTP 인증번호", example = "123456", required = true)
+    String code;
 }

--- a/src/main/java/com/season/livingmate/auth/dto/response/RefreshTokenResDto.java
+++ b/src/main/java/com/season/livingmate/auth/dto/response/RefreshTokenResDto.java
@@ -1,0 +1,28 @@
+package com.season.livingmate.auth.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.season.livingmate.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class RefreshTokenResDto {
+
+    @Schema(description = "발급된 Access Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+    private String accessToken;
+
+    @Schema(description = "발급된 Refresh Token", example = "dGhpc2lzaXJyYW5kb21zdHJpbmc...")
+    private String refreshToken;
+
+    public static RefreshTokenResDto from(String accessToken, String refreshToken) {
+        return new RefreshTokenResDto(
+                accessToken,
+                refreshToken
+        );
+    }
+}

--- a/src/main/java/com/season/livingmate/auth/dto/response/SignupResDto.java
+++ b/src/main/java/com/season/livingmate/auth/dto/response/SignupResDto.java
@@ -1,0 +1,38 @@
+package com.season.livingmate.auth.dto.response;
+
+import com.season.livingmate.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@AllArgsConstructor
+@Setter
+@Getter
+public class SignupResDto {
+
+    @Schema(description = "사용자 고유 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "사용자 아이디", example = "testuser")
+    private String username;
+
+    @Schema(description = "사용자 닉네임", example = "nickname123")
+    private String nickname;
+
+    @Schema(description = "발급된 Access Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+    private String accessToken;
+
+    @Schema(description = "발급된 Refresh Token", example = "dGhpc2lzaXJyYW5kb21zdHJpbmc...")
+    private String refreshToken;
+
+    public static SignupResDto from(User user, String accessToken, String refreshToken) {
+        return new SignupResDto(
+                user.getId(),
+                user.getUsername(),
+                user.getNickname(),
+                accessToken,
+                refreshToken
+        );
+    }
+}

--- a/src/main/java/com/season/livingmate/auth/entity/BlacklistReason.java
+++ b/src/main/java/com/season/livingmate/auth/entity/BlacklistReason.java
@@ -1,0 +1,7 @@
+package com.season.livingmate.auth.entity;
+
+public enum BlacklistReason {
+    LOGOUT,            // 사용자가 직접 로그아웃
+    ADMIN_FORCED,      // 관리자가 강제 로그아웃
+    SUSPICIOUS_LOGIN   // 다른 IP / 위치에서 로그인 탐지
+}

--- a/src/main/java/com/season/livingmate/auth/entity/BlacklistToken.java
+++ b/src/main/java/com/season/livingmate/auth/entity/BlacklistToken.java
@@ -1,0 +1,29 @@
+package com.season.livingmate.auth.entity;
+
+import com.season.livingmate.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class BlacklistToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String blacklistToken;
+
+    private BlacklistReason reason;
+
+    private Long expiredAt;
+
+    private boolean isRevoked;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+}

--- a/src/main/java/com/season/livingmate/auth/entity/RefreshToken.java
+++ b/src/main/java/com/season/livingmate/auth/entity/RefreshToken.java
@@ -1,0 +1,32 @@
+package com.season.livingmate.auth.entity;
+
+import com.season.livingmate.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String refreshToken;
+
+    private Long expiredAt;
+
+    private boolean revoked;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    public void revoke() {
+        this.revoked = true;
+    }
+}

--- a/src/main/java/com/season/livingmate/auth/repository/BlacklistTokenRepository.java
+++ b/src/main/java/com/season/livingmate/auth/repository/BlacklistTokenRepository.java
@@ -1,0 +1,14 @@
+package com.season.livingmate.auth.repository;
+
+import com.season.livingmate.auth.entity.BlacklistToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface BlacklistTokenRepository extends JpaRepository<BlacklistToken, Long> {
+    boolean existsByBlacklistToken(String token); // 블랙리스트 여부 체크
+
+    Optional<BlacklistToken> findByBlacklistToken(String token);
+}

--- a/src/main/java/com/season/livingmate/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/season/livingmate/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package com.season.livingmate.auth.repository;
+
+import com.season.livingmate.auth.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+}

--- a/src/main/java/com/season/livingmate/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/season/livingmate/auth/repository/RefreshTokenRepository.java
@@ -1,7 +1,17 @@
 package com.season.livingmate.auth.repository;
 
 import com.season.livingmate.auth.entity.RefreshToken;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+
+import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    @Modifying
+    @Transactional
+    void deleteByUser_Id(Long userId);
+
+    // userId로 RefreshToken 조회
+    Optional<RefreshToken> findByUser_Id(Long userId);
 }

--- a/src/main/java/com/season/livingmate/auth/security/CustomLogoutFilter.java
+++ b/src/main/java/com/season/livingmate/auth/security/CustomLogoutFilter.java
@@ -1,0 +1,66 @@
+package com.season.livingmate.auth.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.season.livingmate.auth.entity.BlacklistReason;
+import com.season.livingmate.auth.repository.RefreshTokenRepository;
+import com.season.livingmate.auth.service.BlacklistService;
+import com.season.livingmate.auth.service.LogoutService;
+import com.season.livingmate.exception.Response;
+import com.season.livingmate.exception.status.ErrorStatus;
+import com.season.livingmate.exception.status.SuccessStatus;
+import com.season.livingmate.user.entity.User;
+import com.season.livingmate.user.repository.UserRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Date;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class CustomLogoutFilter extends OncePerRequestFilter {
+
+    private final LogoutService logoutService; // 모든 비즈니스 로직 위임
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String accessToken = logoutService.resolveAccessToken(request);
+
+        // 1️⃣ 블랙리스트 체크
+        if (accessToken != null && logoutService.isBlacklisted(accessToken)) {
+            sendErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, ErrorStatus.UNAUTHORIZED);
+            return;
+        }
+
+        // 2️⃣ 로그아웃 요청 처리
+        if ("/auth/logout".equals(request.getRequestURI()) && "POST".equalsIgnoreCase(request.getMethod())) {
+            logoutService.logout(accessToken, response);
+            return;
+        }
+
+        // 3️⃣ 그 외 요청은 다음 필터로
+        filterChain.doFilter(request, response);
+    }
+
+    private void sendErrorResponse(HttpServletResponse response, int status, ErrorStatus errorStatus) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(status);
+        objectMapper.writeValue(response.getWriter(), Response.fail(errorStatus));
+    }
+}

--- a/src/main/java/com/season/livingmate/auth/security/CustomUserDetailService.java
+++ b/src/main/java/com/season/livingmate/auth/security/CustomUserDetailService.java
@@ -1,0 +1,31 @@
+package com.season.livingmate.auth.security;
+
+import com.season.livingmate.user.entity.User;
+import com.season.livingmate.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class CustomUserDetailService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    // 사용자의 이름(또는 ID, 이메일 등)을 입력받아 데이터베이스 등에서 사용자를 검색
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Optional<User> user = userRepository.findByUsername(username);
+
+        if(user.isEmpty()) {
+            throw new UsernameNotFoundException("사용자를 찾을 수 없습니다. " + username);
+        }
+
+        return new CustomUserDetails(user.get());
+    }
+}

--- a/src/main/java/com/season/livingmate/auth/security/CustomUserDetails.java
+++ b/src/main/java/com/season/livingmate/auth/security/CustomUserDetails.java
@@ -1,0 +1,63 @@
+package com.season.livingmate.auth.security;
+
+import com.season.livingmate.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+    private final User user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+
+        Collection<GrantedAuthority> authorities = new ArrayList<GrantedAuthority>();
+
+        authorities.add(new GrantedAuthority() {
+            @Override
+            public String getAuthority() {
+                return null;
+            }
+        });
+
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUsername();
+    }
+
+    public Long getUserId(){
+        return user.getId();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return UserDetails.super.isAccountNonExpired();
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return UserDetails.super.isAccountNonLocked();
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return UserDetails.super.isCredentialsNonExpired();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return UserDetails.super.isEnabled();
+    }
+}

--- a/src/main/java/com/season/livingmate/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/season/livingmate/auth/security/JwtAuthenticationFilter.java
@@ -1,0 +1,100 @@
+package com.season.livingmate.auth.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.season.livingmate.exception.CustomException;
+import com.season.livingmate.exception.Response;
+import com.season.livingmate.exception.status.ErrorStatus;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+@Component
+@AllArgsConstructor
+@Slf4j
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtProvider jwtProvider;
+    private final CustomUserDetailService customUserDetailService;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String header = request.getHeader("Authorization");
+
+        //Authorization 헤더 검증
+        if (header == null || !header.startsWith("Bearer ")) {
+            log.debug("Authorization header missing or invalid: {}", header);
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = header.replace("Bearer ", "");
+        log.info("🔐 Token received: {}", token);
+
+        if (!request.getRequestURI().equals("/auth/refresh")) {
+            setAuthentication(token);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    // 토큰 검증/ 유형 체크 -> Refresh 인지 access인지
+    private boolean isValidToken(HttpServletRequest request, String token, HttpServletResponse response) throws IOException {
+        try {
+            if (request.getRequestURI().equals("/auth/refresh")) {
+                if (!jwtProvider.isRefreshToken(token)) {
+                    sendErrorResponse(response, ErrorStatus.BAD_REQUEST);
+                    return false;
+                }
+                return true; // Refresh Token이면 통과
+            }
+
+            if (jwtProvider.isExpired(token)) {
+                sendErrorResponse(response, ErrorStatus.ACCESS_TOKEN_EXPIRED);
+                return false;
+            }
+
+            if (!jwtProvider.isAccessToken(token)) {
+                sendErrorResponse(response, ErrorStatus.INVALID_ACCESS_TOKEN);
+                return false;
+            }
+
+            return true;
+        } catch (CustomException e) {
+            sendErrorResponse(response, e.getErrorCode());
+            return false;
+        }
+    }
+
+    private void setAuthentication(String token) {
+        String email = jwtProvider.getUsername(token);
+        UserDetails userDetails = customUserDetailService.loadUserByUsername(email);
+
+        Authentication authToken =
+                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+    }
+
+    private void sendErrorResponse(HttpServletResponse response, ErrorStatus errorStatus) throws IOException {
+        response.setStatus(errorStatus.getStatus().value());
+        response.setContentType("application/json; charset=UTF-8");
+        Response<?> errorResponse = Response.fail(errorStatus);
+        String json = objectMapper.writeValueAsString(errorResponse);
+        PrintWriter writer = response.getWriter();
+        writer.print(json);
+        writer.flush();
+    }
+
+}

--- a/src/main/java/com/season/livingmate/auth/security/JwtBlacklistFilter.java
+++ b/src/main/java/com/season/livingmate/auth/security/JwtBlacklistFilter.java
@@ -1,0 +1,58 @@
+package com.season.livingmate.auth.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.season.livingmate.auth.service.BlacklistService;
+import com.season.livingmate.exception.Response;
+import com.season.livingmate.exception.status.ErrorStatus;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtBlacklistFilter extends OncePerRequestFilter {
+    private final JwtProvider jwtProvider;
+    private final BlacklistService blacklistService;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+
+        String token = resolveToken(request);
+
+        if (token != null && jwtProvider.isAccessToken(token)) {
+            boolean isBlacklisted = blacklistService.isBlacklisted(token);
+
+            if (isBlacklisted) {
+                log.info("블랙리스트 토큰 접근 시도: {}", token);
+
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.setContentType("application/json;charset=UTF-8");
+                Response<?> apiRes = Response.fail(ErrorStatus.UNAUTHORIZED);
+                objectMapper.writeValue(response.getWriter(), apiRes);
+                return; // 요청 중단
+            }
+        }
+
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/season/livingmate/auth/security/JwtProvider.java
+++ b/src/main/java/com/season/livingmate/auth/security/JwtProvider.java
@@ -1,0 +1,123 @@
+package com.season.livingmate.auth.security;
+
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+// JWT 토큰을 생성/검증
+// 보통 access token을 만들어주고, 클라이언트가 보낸 JWT의 유효성을 확인하는 핵심 기능을 수행
+@Component
+@Slf4j
+public class JwtProvider {
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.expiration}")
+    private long accessExpiration;
+
+    @Value("${jwt.refresh-token-expiration}")
+    private long refreshExpiration;
+
+    private SecretKey secretKey;
+    private JwtParser jwtParser;
+
+    @PostConstruct
+    public void init() {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.jwtParser = Jwts.parser().verifyWith(secretKey).build();
+    }
+
+    // 토큰 생성
+    public String generateAccessToken(Long userId) {
+        return Jwts.builder()
+                .subject(userId.toString())
+                .claim("userId", userId)
+                .claim("type", "accessToken")
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + accessExpiration))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public String generateRefreshToken(Long userId) {
+        return Jwts.builder()
+                .subject(userId.toString())
+                .claim("userId", userId)
+                .claim("type", "refreshToken")
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + refreshExpiration))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    // 토큰 검증
+    public String getUsername(String token) {
+        return jwtParser.parseSignedClaims(token)
+                .getPayload()
+                .get("username", String.class);
+    }
+
+    public Long getUserId(String token ) {
+        return jwtParser.parseSignedClaims(token)
+                .getPayload()
+                .get("userId", Long.class);
+    }
+
+
+    public Boolean isExpired(String token) {
+        return jwtParser.parseSignedClaims(token)
+                .getPayload()
+                .getExpiration().before(new Date());
+    }
+
+    public Boolean isAccessToken(String token) {
+        try {
+            String type = jwtParser.parseSignedClaims(token)
+                    .getPayload()
+                    .get("type", String.class);
+            return "accessToken".equals(type);
+        } catch (Exception e) {
+            return false; // type 클레임 없음 or 파싱 오류
+        }
+    }
+
+    public Boolean isRefreshToken(String token) {
+        try {
+            String type = jwtParser.parseSignedClaims(token)
+                    .getPayload()
+                    .get("type", String.class);
+            return "refreshToken".equals(type);
+        } catch (Exception e) {
+            return false; // type 클레임 없음 or 파싱 오류
+        }
+    }
+
+
+    public Claims getClaims(String token) {
+        return jwtParser.parseSignedClaims(token).getPayload();
+    }
+
+    // ?
+    // 토큰 유효성
+    public boolean validateToken(String token) {
+        try {
+            jwtParser.parseSignedClaims(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            // 토큰이 만료되었지만 사용자가 재발급 시도 중일 수 있음
+            return false;
+        } catch (JwtException | IllegalArgumentException e) {
+            // 변조된 토큰
+            return false;
+        }
+    }
+
+}

--- a/src/main/java/com/season/livingmate/auth/security/LoginFilter.java
+++ b/src/main/java/com/season/livingmate/auth/security/LoginFilter.java
@@ -1,0 +1,107 @@
+package com.season.livingmate.auth.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.season.livingmate.auth.dto.request.LoginReqDto;
+import com.season.livingmate.auth.repository.RefreshTokenRepository;
+import com.season.livingmate.auth.service.RefreshTokenService;
+import com.season.livingmate.exception.CustomException;
+import com.season.livingmate.exception.Response;
+import com.season.livingmate.exception.status.ErrorStatus;
+import com.season.livingmate.exception.status.SuccessStatus;
+import com.season.livingmate.user.entity.User;
+import com.season.livingmate.user.repository.UserRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Slf4j
+public class LoginFilter extends UsernamePasswordAuthenticationFilter {
+    private final AuthenticationManager authenticationManager;
+    private final JwtProvider jwtProvider;
+    private final ObjectMapper objectMapper; // json과 객체간의 변환을 담당, LocalDateTime 직렬화 문제
+    private final RefreshTokenService refreshTokenService;
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
+            throws AuthenticationException {
+
+        try{
+            LoginReqDto reqDto = objectMapper.readValue(request.getInputStream(), LoginReqDto.class);
+
+            String username = reqDto.getUsername();
+            String password = reqDto.getPassword();
+
+            // 일종의 dto
+            UsernamePasswordAuthenticationToken token =
+                    new UsernamePasswordAuthenticationToken(username, password, null);
+
+            // token에 담은 검증을 위한 AuthenticationManager에게 넘겨줌
+            return authenticationManager.authenticate(token);
+        }catch(Exception e){
+            throw new AuthenticationServiceException(e.getMessage());
+        }
+    }
+
+    // 로그인 성공 시 실행하는 메소드 - jwt 발급
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) throws
+            IOException {
+        log.info("💡 로그인 성공");
+
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        String username = userDetails.getUsername();
+        Long userId = userDetails.getUserId();
+
+        String accessToken = jwtProvider.generateAccessToken(userId);
+        String refreshToken = jwtProvider.generateRefreshToken(userId);
+        refreshTokenService.saveRefreshToken(userId, refreshToken, 86400000L);
+
+        // accessToken
+        response.setHeader("Authorization", "Bearer " + accessToken);
+
+        Map<String, Object> map = new HashMap<>();
+        map.put("userId", userId);
+        map.put("username", username);
+        map.put("accessToken", accessToken);
+        map.put("refreshToken", refreshToken);
+
+        Response<Map<String, Object>> apiRes = Response.success(SuccessStatus.SUCCESS,map);
+
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_OK);
+
+        objectMapper.writeValue(response.getWriter(), apiRes);
+    }
+
+
+    // 로그인 실패시 실행하는 메소드
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws
+            IOException {
+        log.info("❌ 로그인 실패");
+        // 예: "이메일 또는 비밀번호가 잘못되었습니다"
+        ErrorStatus errorStatus = ErrorStatus.UNAUTHORIZED; // 기본값
+
+        Response<?> errorResponse = Response.fail(errorStatus);
+
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+
+        objectMapper.writeValue(response.getWriter(), errorResponse);
+
+    }
+}

--- a/src/main/java/com/season/livingmate/auth/service/AuthService.java
+++ b/src/main/java/com/season/livingmate/auth/service/AuthService.java
@@ -1,0 +1,9 @@
+package com.season.livingmate.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+}

--- a/src/main/java/com/season/livingmate/auth/service/BlacklistService.java
+++ b/src/main/java/com/season/livingmate/auth/service/BlacklistService.java
@@ -1,0 +1,40 @@
+package com.season.livingmate.auth.service;
+
+
+import com.season.livingmate.auth.entity.BlacklistReason;
+import com.season.livingmate.auth.entity.BlacklistToken;
+import com.season.livingmate.auth.repository.BlacklistTokenRepository;
+import com.season.livingmate.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class BlacklistService {
+    private final BlacklistTokenRepository blacklistTokenRepository;
+
+    // 블랙리스트 등록
+    public void addToBlacklist(String accessToken, BlacklistReason reason, Long remainingMillis, User user) {
+        BlacklistToken token = BlacklistToken.builder()
+                .blacklistToken(accessToken)
+                .reason(reason)
+                .expiredAt(System.currentTimeMillis() + remainingMillis)
+                .user(user)
+                .build();
+
+        blacklistTokenRepository.save(token);
+    }
+
+    // 블랙리스트 여부 확인
+    public boolean isBlacklisted(String accessToken) {
+        return blacklistTokenRepository.existsByBlacklistToken(accessToken);
+    }
+
+    // 사유 조회
+    public Optional<BlacklistToken> getBlacklistInfo(String token) {
+        return blacklistTokenRepository.findByBlacklistToken(token);
+    }
+
+}

--- a/src/main/java/com/season/livingmate/auth/service/LogoutService.java
+++ b/src/main/java/com/season/livingmate/auth/service/LogoutService.java
@@ -1,0 +1,96 @@
+package com.season.livingmate.auth.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.season.livingmate.auth.entity.BlacklistReason;
+import com.season.livingmate.auth.repository.RefreshTokenRepository;
+import com.season.livingmate.auth.security.JwtProvider;
+import com.season.livingmate.exception.Response;
+import com.season.livingmate.exception.status.ErrorStatus;
+import com.season.livingmate.exception.status.SuccessStatus;
+import com.season.livingmate.user.entity.User;
+import com.season.livingmate.user.repository.UserRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class LogoutService {
+
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final BlacklistService blacklistService;
+    private final UserRepository userRepository;
+    private final ObjectMapper objectMapper;
+
+    public void logout(String accessToken, HttpServletResponse response) throws IOException {
+        if (accessToken == null || accessToken.isEmpty()) {
+            sendErrorResponse(response, HttpServletResponse.SC_BAD_REQUEST, ErrorStatus.INVALID_ACCESS_TOKEN);
+            return;
+        }
+
+        try {
+            if (!jwtProvider.isAccessToken(accessToken)) {
+                sendErrorResponse(response, HttpServletResponse.SC_BAD_REQUEST, ErrorStatus.INVALID_ACCESS_TOKEN);
+                return;
+            }
+
+            // 사용자 조회
+            Long userId = jwtProvider.getUserId(accessToken);
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new RuntimeException("User not found"));
+
+            // Access Token → 블랙리스트 등록
+            long remainingMillis = getRemainingMillis(accessToken);
+            blacklistService.addToBlacklist(accessToken, BlacklistReason.LOGOUT, remainingMillis, user);
+
+            // Refresh Token → DB에서 삭제
+            refreshTokenRepository.deleteByUser_Id(userId);
+
+            sendSuccessResponse(response, SuccessStatus.SUCCESS, null);
+
+        } catch (ExpiredJwtException e) {
+            sendErrorResponse(response, HttpServletResponse.SC_BAD_REQUEST, ErrorStatus.ACCESS_TOKEN_EXPIRED);
+        } catch (Exception e) {
+            log.error("Logout error", e);
+            sendErrorResponse(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, ErrorStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public boolean isBlacklisted(String token) {
+        return blacklistService.isBlacklisted(token);
+    }
+
+    public String resolveAccessToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    private long getRemainingMillis(String token) {
+        Date expiration = jwtProvider.getClaims(token).getExpiration();
+        return expiration.getTime() - System.currentTimeMillis();
+    }
+
+    private void sendErrorResponse(HttpServletResponse response, int status, ErrorStatus errorStatus) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(status);
+        objectMapper.writeValue(response.getWriter(), Response.fail(errorStatus));
+    }
+
+    private void sendSuccessResponse(HttpServletResponse response, SuccessStatus status, Object data) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_OK);
+        objectMapper.writeValue(response.getWriter(), Response.success(status, data));
+    }
+}

--- a/src/main/java/com/season/livingmate/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/season/livingmate/auth/service/RefreshTokenService.java
@@ -1,0 +1,31 @@
+package com.season.livingmate.auth.service;
+
+import com.season.livingmate.auth.entity.RefreshToken;
+import com.season.livingmate.auth.repository.RefreshTokenRepository;
+import com.season.livingmate.exception.CustomException;
+import com.season.livingmate.exception.status.ErrorStatus;
+import com.season.livingmate.user.entity.User;
+import com.season.livingmate.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final UserRepository userRepository;
+
+    public void saveRefreshToken(Long userId, String refreshToken, Long expiredMs) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorStatus.USER_NOT_FOUND));
+
+        RefreshToken token = RefreshToken.builder()
+                .user(user)
+                .refreshToken(refreshToken)
+                .expiredAt(expiredMs)
+                .build();
+
+        refreshTokenRepository.save(token);
+    }
+}

--- a/src/main/java/com/season/livingmate/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/season/livingmate/auth/service/RefreshTokenService.java
@@ -1,20 +1,70 @@
 package com.season.livingmate.auth.service;
 
+import com.season.livingmate.auth.dto.response.RefreshTokenResDto;
 import com.season.livingmate.auth.entity.RefreshToken;
 import com.season.livingmate.auth.repository.RefreshTokenRepository;
+import com.season.livingmate.auth.security.JwtProvider;
 import com.season.livingmate.exception.CustomException;
 import com.season.livingmate.exception.status.ErrorStatus;
 import com.season.livingmate.user.entity.User;
 import com.season.livingmate.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class RefreshTokenService {
 
     private final RefreshTokenRepository refreshTokenRepository;
     private final UserRepository userRepository;
+    private final JwtProvider jwtProvider;
+
+    @Transactional
+    public RefreshTokenResDto refreshToken(String oldRefreshToken) {
+
+        // 토큰 유효성 검증
+        validateRefreshToken(oldRefreshToken);
+
+        // 사용자 정보 조회
+        Long userId = jwtProvider.getUserId(oldRefreshToken);
+
+        // 기존 토큰 조회 및 일치 여부 확인
+        RefreshToken existingToken = refreshTokenRepository.findByUser_Id(userId)
+                .orElseThrow(() -> new CustomException(ErrorStatus.UNAUTHORIZED));
+
+        if (!existingToken.getRefreshToken().equals(oldRefreshToken)) {
+            throw new CustomException(ErrorStatus.UNAUTHORIZED);
+        }
+
+        // 토큰 rotation: 기존 토큰 삭제
+        refreshTokenRepository.deleteByUser_Id(userId);
+
+        // 새로운 토큰 발급
+        String newAccessToken = jwtProvider.generateAccessToken(userId);
+        String newRefreshToken = jwtProvider.generateRefreshToken(userId);
+
+        log.info("Refresh token rotation for user {}: old={} new={}", userId, oldRefreshToken, newRefreshToken);
+
+        // 새 refreshToken 저장
+        saveRefreshToken(userId, newRefreshToken, System.currentTimeMillis() + 86400000L);
+
+        return RefreshTokenResDto.from(newAccessToken, newRefreshToken);
+    }
+
+    // 토큰 검증 로직을 별도 메서드로 분리
+    private void validateRefreshToken(String refreshToken) {
+        if (jwtProvider.isExpired(refreshToken)) {
+            throw new CustomException(ErrorStatus.REFRESH_TOKEN_EXPIRED);
+        }
+
+        if (!jwtProvider.isRefreshToken(refreshToken)) {
+            throw new CustomException(ErrorStatus.ACCESS_TOKEN_EXPIRED);
+        }
+    }
+
 
     public void saveRefreshToken(Long userId, String refreshToken, Long expiredMs) {
         User user = userRepository.findById(userId)

--- a/src/main/java/com/season/livingmate/auth/service/SignupService.java
+++ b/src/main/java/com/season/livingmate/auth/service/SignupService.java
@@ -3,6 +3,7 @@ package com.season.livingmate.auth.service;
 import com.season.livingmate.auth.dto.request.SignupReqDto;
 import com.season.livingmate.auth.dto.request.VerifyOtpReqDto;
 import com.season.livingmate.auth.dto.response.SignupResDto;
+import com.season.livingmate.auth.security.JwtProvider;
 import com.season.livingmate.exception.CustomException;
 import com.season.livingmate.exception.status.ErrorStatus;
 import com.season.livingmate.user.entity.User;
@@ -30,6 +31,7 @@ public class SignupService {
     private DefaultMessageService messageService;
     private final Map<String, SignupService.OtpInfo> otpStore = new ConcurrentHashMap<>();
     private final Map<String, SignupReqDto> tempSignupStore = new ConcurrentHashMap<>();
+    private final JwtProvider jwtProvider;
 
     @Value("${solapi.apiKey}")
     private String apiKey;
@@ -126,10 +128,10 @@ public class SignupService {
         userRepository.save(user);
 
 //        // JWT 토큰 발급
-//        String accessToken = jwtProvider.generateAccessToken(user.getId());
-//        String refreshToken = jwtProvider.generateRefreshToken(user.getId());
+        String accessToken = jwtProvider.generateAccessToken(user.getId());
+        String refreshToken = jwtProvider.generateRefreshToken(user.getId());
 
-        return SignupResDto.from(user, null, null);
+        return SignupResDto.from(user, accessToken, refreshToken);
     }
 
     // OTP 정보 record

--- a/src/main/java/com/season/livingmate/auth/service/SignupService.java
+++ b/src/main/java/com/season/livingmate/auth/service/SignupService.java
@@ -1,0 +1,138 @@
+package com.season.livingmate.auth.service;
+
+import com.season.livingmate.auth.dto.request.SignupReqDto;
+import com.season.livingmate.auth.dto.request.VerifyOtpReqDto;
+import com.season.livingmate.auth.dto.response.SignupResDto;
+import com.season.livingmate.exception.CustomException;
+import com.season.livingmate.exception.status.ErrorStatus;
+import com.season.livingmate.user.entity.User;
+import com.season.livingmate.user.repository.UserRepository;
+import jakarta.annotation.PostConstruct;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+@RequiredArgsConstructor
+public class SignupService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private DefaultMessageService messageService;
+    private final Map<String, SignupService.OtpInfo> otpStore = new ConcurrentHashMap<>();
+    private final Map<String, SignupReqDto> tempSignupStore = new ConcurrentHashMap<>();
+
+    @Value("${solapi.apiKey}")
+    private String apiKey;
+
+    @Value("${solapi.secretkey}")
+    private String apiSecret;
+
+    // OTP 유효시간 3분
+    private static final long OTP_VALID_DURATION = 3 * 60 * 1000;
+
+    @PostConstruct
+    public void init() {
+        this.messageService = NurigoApp.INSTANCE.initialize(
+                apiKey,
+                apiSecret,
+                "https://api.solapi.com"
+        );
+    }
+
+    @Transactional
+    public void signup(SignupReqDto signupReqDto){
+        validateDuplicateUsername(signupReqDto.getUsername());
+
+        SignupReqDto encryptedDto = new SignupReqDto();
+        encryptedDto.setUsername(signupReqDto.getUsername());
+        encryptedDto.setNickname(signupReqDto.getNickname());
+        encryptedDto.setGender(signupReqDto.getGender());
+        encryptedDto.setAge(signupReqDto.getAge());
+        encryptedDto.setRoom(signupReqDto.isRoom());
+        encryptedDto.setPassword(passwordEncoder.encode(signupReqDto.getPassword()));
+        encryptedDto.setConfirmPassword(null); // 검증 후 필요 없음
+
+        tempSignupStore.put(encryptedDto.getUsername(), encryptedDto);
+
+    }
+
+    // 아이디 중복 검사
+    public void validateDuplicateUsername(String username) {
+        if(userRepository.existsByUsername(username)) {
+            throw new CustomException(ErrorStatus.DUPLICATE_RESOURCE);
+        }
+    }
+
+    // OTP 발송
+    @Transactional
+    public void sendOtp(String phone) throws Exception {
+        String otp = String.valueOf((int)((Math.random() * 900000) + 100000));
+
+        Message message = new Message();
+        message.setFrom("01083548871");
+        message.setTo(phone);
+        message.setText("[인증번호] " + otp + "를 입력해주세요.");
+
+        try{
+            this.messageService.sendOne(new SingleMessageSendingRequest(message));
+        }catch(Exception e ){
+            throw new CustomException(ErrorStatus.OTP_SEND_FAILED);
+        }
+
+        // OTP와 만료시간 저장
+        otpStore.put(phone, new SignupService.OtpInfo(otp, System.currentTimeMillis() + OTP_VALID_DURATION));
+    }
+
+    // OTP 검증 후 유저 정보 db에 저장
+    @Transactional
+    public SignupResDto verifyOtp(VerifyOtpReqDto dto) throws Exception {
+        String phone = dto.getPhoneNumber();
+        String username = dto.getUsername();
+        SignupService.OtpInfo info = otpStore.get(dto.getPhoneNumber());
+
+
+        if (info == null) throw new CustomException(ErrorStatus.OTP_NOT_FOUND); // OTP 정보 조회
+
+        SignupReqDto signupInfo = tempSignupStore.get(username);
+        if (phone == null) throw new CustomException(ErrorStatus.RESOURCE_NOT_FOUND); // 임시 회원가입 정보 조회
+
+        if (System.currentTimeMillis() > info.expireAt()) throw new CustomException(ErrorStatus.OTP_EXPIRED); // OPT 만료시간
+        if (!info.otp().equals(dto.getCode())) throw new CustomException(ErrorStatus.OTP_MISMATCH);
+
+
+        otpStore.remove(phone);
+        tempSignupStore.remove(phone);
+
+        User user = User.builder()
+                .username(signupInfo.getUsername())
+                .nickname(signupInfo.getNickname())
+                .password(signupInfo.getPassword()) // 이미 암호화된 비밀번호
+                .gender(signupInfo.getGender())
+                .age(signupInfo.getAge())
+                .isRoom(signupInfo.isRoom())
+                .verified(true)
+                .build();
+
+        userRepository.save(user);
+
+//        // JWT 토큰 발급
+//        String accessToken = jwtProvider.generateAccessToken(user.getId());
+//        String refreshToken = jwtProvider.generateRefreshToken(user.getId());
+
+        return SignupResDto.from(user, null, null);
+    }
+
+    // OTP 정보 record
+    private record OtpInfo(String otp, long expireAt) {}
+
+}

--- a/src/main/java/com/season/livingmate/config/SecurityConfig.java
+++ b/src/main/java/com/season/livingmate/config/SecurityConfig.java
@@ -2,9 +2,7 @@ package com.season.livingmate.config;
 
 import java.util.Collections;
 
-import com.season.livingmate.auth.security.JwtAuthenticationFilter;
-import com.season.livingmate.auth.security.JwtProvider;
-import com.season.livingmate.auth.security.LoginFilter;
+import com.season.livingmate.auth.security.*;
 import com.season.livingmate.auth.service.AuthService;
 import com.season.livingmate.auth.service.RefreshTokenService;
 import com.season.livingmate.user.repository.UserRepository;
@@ -55,7 +53,7 @@ public class SecurityConfig {
 	}
 
 	@Bean
-	public SecurityFilterChain filterChain(HttpSecurity http, AuthenticationManager authManager) throws Exception {
+	public SecurityFilterChain filterChain(HttpSecurity http, AuthenticationManager authManager, CustomLogoutFilter customLogoutFilter, JwtBlacklistFilter jwtBlacklistFilter) throws Exception {
 		LoginFilter loginFilter = new LoginFilter(authManager,  jwtProvider, objectMapper, refreshTokenService);
 		loginFilter.setFilterProcessesUrl("/auth/login");
 
@@ -82,9 +80,9 @@ public class SecurityConfig {
 					}
 				}))
 
-			// .addFilterBefore(customLogoutFilter, LogoutFilter.class)
-			// .addFilterBefore(jwtAuthenticationFilter, LoginFilter.class)
-			// .addFilterBefore(jwtBlacklistFilter, JwtAuthenticationFilter.class)
+			 .addFilterBefore(customLogoutFilter, LogoutFilter.class)
+			 .addFilterBefore(jwtAuthenticationFilter, LoginFilter.class)
+			 .addFilterBefore(jwtBlacklistFilter, JwtAuthenticationFilter.class)
 			 .addFilterAt(loginFilter, UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();

--- a/src/main/java/com/season/livingmate/config/SecurityConfig.java
+++ b/src/main/java/com/season/livingmate/config/SecurityConfig.java
@@ -2,6 +2,12 @@ package com.season.livingmate.config;
 
 import java.util.Collections;
 
+import com.season.livingmate.auth.security.JwtAuthenticationFilter;
+import com.season.livingmate.auth.security.JwtProvider;
+import com.season.livingmate.auth.security.LoginFilter;
+import com.season.livingmate.auth.service.AuthService;
+import com.season.livingmate.auth.service.RefreshTokenService;
+import com.season.livingmate.user.repository.UserRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -31,8 +37,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-	//private final JwtProvider jwtProvider;
-	//private final ObjectMapper objectMapper;
+	private final JwtProvider jwtProvider;
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+	private final ObjectMapper objectMapper;
+	private final RefreshTokenService refreshTokenService;
+	//private final AuthService authService;
+	private final UserRepository userRepository;
 
 	@Bean
 	public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
@@ -45,9 +55,9 @@ public class SecurityConfig {
 	}
 
 	@Bean
-	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-		//LoginFilter loginFilter = new LoginFilter(authenticationManager(authenticationConfiguration),  jwtProvider, objectMapper, authService);
-		//loginFilter.setFilterProcessesUrl("/api/v1/users/login");
+	public SecurityFilterChain filterChain(HttpSecurity http, AuthenticationManager authManager) throws Exception {
+		LoginFilter loginFilter = new LoginFilter(authManager,  jwtProvider, objectMapper, refreshTokenService);
+		loginFilter.setFilterProcessesUrl("/auth/login");
 
 		http
 			.csrf(AbstractHttpConfigurer::disable)  // CSRF 비활성화, jwt 방식은 csrf에 대한 공격을 방어하지 않아도 됨
@@ -71,12 +81,11 @@ public class SecurityConfig {
 						return config;
 					}
 				}))
-		;
 
 			// .addFilterBefore(customLogoutFilter, LogoutFilter.class)
 			// .addFilterBefore(jwtAuthenticationFilter, LoginFilter.class)
 			// .addFilterBefore(jwtBlacklistFilter, JwtAuthenticationFilter.class)
-			// .addFilterAt(loginFilter, UsernamePasswordAuthenticationFilter.class)
+			 .addFilterAt(loginFilter, UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();
 	}

--- a/src/main/java/com/season/livingmate/config/SwagerConfig.java
+++ b/src/main/java/com/season/livingmate/config/SwagerConfig.java
@@ -1,5 +1,8 @@
 package com.season.livingmate.config;
 
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,12 +14,27 @@ public class SwagerConfig {
 
 	@Bean
 	public OpenAPI customOpenAPI() {
+
+		String jwtSchemeName = "JWT";
+
+		// Security Requirement 설정
+		SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+
+		// Security Scheme 설정 (헤더에 Authorization: Bearer {token})
+		Components components = new Components()
+				.addSecuritySchemes(jwtSchemeName,
+						new SecurityScheme()
+								.name(jwtSchemeName)
+								.type(SecurityScheme.Type.HTTP)
+								.scheme("bearer")
+								.bearerFormat("JWT"));
+
 		return new OpenAPI()
 			.info(new Info()
 				.title("Livingmate API")
-				.description("Livingmate REST API 문서입니다."))
-
-			;
-
+				.description("Livingmate REST API 문서입니다.")
+			)
+				.addSecurityItem(securityRequirement)
+				.components(components);
 	}
 }

--- a/src/main/java/com/season/livingmate/exception/status/ErrorStatus.java
+++ b/src/main/java/com/season/livingmate/exception/status/ErrorStatus.java
@@ -14,10 +14,20 @@ public enum ErrorStatus {
     FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON404", "찾을 수 없는 리소스입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON404", "사용자를 찾을 수 없습니다"),
-    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON405", "허용되지 않는 HTTP Method입니다.");
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON405", "허용되지 않는 HTTP Method입니다."),
+    DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "COMMON409", "이미 존재하는 리소스입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COOMON401", "권한이 없습니다."),
 
     // 도메인별로
+    OTP_SEND_FAILED(HttpStatus.BAD_REQUEST, "OTP500", "OTP 전송에 실패했습니다."),
+    OTP_MISMATCH(HttpStatus.BAD_REQUEST, "OTP400", "OTP가 일치하지 않습니다."),
+    OTP_EXPIRED(HttpStatus.BAD_REQUEST, "OPT400", "OTP가 만료되었습니다"),
+    OTP_NOT_FOUND(HttpStatus.BAD_REQUEST, "OPT400", "OTP정보가 없습니다."),
 
+    ACCESS_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST,"TOKEN400","엑세스 토큰이 만료되었습니다."),
+    INVALID_ACCESS_TOKEN(HttpStatus.BAD_REQUEST,"TOKEN400","유효하지 않은 토큰입니다."),
+    REFRESH_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST,"TOKEN400","엑세스 토큰이 만료되었습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER500", "서버 오류가 발생했습니다.");
     private final HttpStatus status;
     private final String code;
     private final String message;

--- a/src/main/java/com/season/livingmate/global/entity/BaseEntity.java
+++ b/src/main/java/com/season/livingmate/global/entity/BaseEntity.java
@@ -1,0 +1,22 @@
+package com.season.livingmate.global.entity;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass // JPA Entity 클래스들이 BaseTimeEntity를 상속 할 경우 createdDate, modifiedDate 두 필드도 컬럼으로 인식하도록 설정
+@EntityListeners(AuditingEntityListener.class) //BaseTimeEntity 클래스에 Auditing 기능을 포함
+public abstract class BaseEntity {
+
+    @CreatedDate // 생성 시 날짜 자동 생성
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate // 수정 시 날짜 자동 생성
+    private LocalDateTime modifiedDate;
+}

--- a/src/main/java/com/season/livingmate/user/entity/Gender.java
+++ b/src/main/java/com/season/livingmate/user/entity/Gender.java
@@ -1,0 +1,5 @@
+package com.season.livingmate.user.entity;
+
+public enum Gender {
+    MALE, FEMALE
+}

--- a/src/main/java/com/season/livingmate/user/entity/User.java
+++ b/src/main/java/com/season/livingmate/user/entity/User.java
@@ -1,0 +1,45 @@
+package com.season.livingmate.user.entity;
+
+import com.season.livingmate.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Gender gender;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Column(nullable = false)
+    private int age;
+
+    @Column(nullable = false)
+    private boolean isRoom;
+
+    private boolean verified; // 본인인증 완료 여부
+
+//    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL)
+//    private UserProfile userProfile;
+
+//    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+//    private List<RefreshToken> refreshTokens;
+}

--- a/src/main/java/com/season/livingmate/user/repository/UserRepository.java
+++ b/src/main/java/com/season/livingmate/user/repository/UserRepository.java
@@ -1,0 +1,16 @@
+package com.season.livingmate.user.repository;
+
+import com.season.livingmate.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsById(Long id);
+
+    Boolean existsByUsername(String username);
+    Optional<User> findByUsername(String username);
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,14 @@ logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.type.descriptor.sql: trace
+
+
+solapi:
+  apiKey: ${SOLAPI_APIKEY}
+  secretkey: ${SOLAPI_SECRETKEY}
+
+jwt:
+  header: ${HEADER}
+  secret: ${SECRET-KEY}
+  expiration: ${EXPIRATION} # 1시간
+  refresh-token-expiration: ${REFRESH-EXPIRATION} # 7일


### PR DESCRIPTION
# 🚀 Pull Request

## 📄 관련 이슈 (Related Issue)
- 이슈 번호: #1 

---

## 🧾 개요 (Description)
1. SMS 인증 회원가입
   - 회원가입 시 휴대폰 번호로 인증번호 전송
   - 인증번호 입력 시 자동 로그인 처리
   - 로그인 성공 시 AccessToken / RefreshToken 발급

2.  JWT 로그인/로그아웃
   - JWT 기반 로그인/로그아웃 필터 구현
   - RefreshToken rotation 전략 적용
   - 로그아웃 시 RefreshToken 블랙리스트 처리

## 🔨 작업 내용 (Changes Made)
- [POST] /auth/signup→ 회원정보 임시 저장
- [POST] /auth/send-otp→ SMS 인증번호 전송 
- [POST] /auth/verify-otp → 인증번호 일치 시 자동 로그인 및 토큰 발급 
- [POST] /auth/login → 정상 로그인 시 JWT 발급
- [POST] /auth/logout → 토큰 블랙리스트 처리 
- [GET] /auth/refresh → RefreshToken rotation 정상 동작

## 📷 스크린샷 (Optional)
UI 변경 사항이 있다면 스크린샷을 첨부해주세요.

## 💬 기타 참고 사항 (Notes)
- 사용한 SMS API: 솔라피