### PR TITLE
[BUG/#15] 로그인 시 refreshToken은 하나만 유지하도록

### DIFF
--- a/src/main/java/com/season/livingmate/auth/entity/RefreshToken.java
+++ b/src/main/java/com/season/livingmate/auth/entity/RefreshToken.java
@@ -20,7 +20,7 @@ public class RefreshToken {
 
     private Long expiredAt;
 
-    private boolean revoked;
+    private boolean revoked; // 사실상 안씀
 
     @ManyToOne
     @JoinColumn(name = "user_id")

--- a/src/main/java/com/season/livingmate/auth/security/LoginFilter.java
+++ b/src/main/java/com/season/livingmate/auth/security/LoginFilter.java
@@ -88,6 +88,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws
             IOException {
         log.info("❌ 로그인 실패");
+        log.info("failed :" + failed.getMessage());
         // 예: "이메일 또는 비밀번호가 잘못되었습니다"
         ErrorStatus errorStatus = ErrorStatus.USER_NOT_FOUND; // 기본값
 

--- a/src/main/java/com/season/livingmate/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/season/livingmate/auth/service/RefreshTokenService.java
@@ -70,6 +70,10 @@ public class RefreshTokenService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorStatus.USER_NOT_FOUND));
 
+        // 기존 토큰이 있으면 삭제
+        refreshTokenRepository.findByUser_Id(userId)
+                .ifPresent(existingToken -> refreshTokenRepository.delete(existingToken));
+
         RefreshToken token = RefreshToken.builder()
                 .user(user)
                 .refreshToken(refreshToken)


### PR DESCRIPTION
# 🚀 Pull Request

## 📄 관련 이슈 (Related Issue)
- 이슈 번호: #15 

## 🧾 개요 (Description)

사용자가 로그인을 여러 번 하면 리프레시 토큰도 여러 개가 생김
리프레시 토큰을 로테이션을 위해 테이블 조회 시 토큰이 여러 개 반환되어 에러 생성


## 🔨 작업 내용 (Changes Made)
사용자가 새로 로그인할 때 기존에 발급된 리프레시 토큰을 삭제해서 유저당 하나의 리프레시토큰만 테이블에 존재하도록 유지